### PR TITLE
Limit the xblock content height.

### DIFF
--- a/nesting/public/css/nesting_edit.css
+++ b/nesting/public/css/nesting_edit.css
@@ -1,6 +1,10 @@
 .xblock--nesting--editor {
   margin-bottom: 0 !important; }
 
+.xblock-content {
+  height: 375px;
+  overflow-y: scroll; }
+
 .hidden {
   display: none; }
 
@@ -64,5 +68,8 @@
 .no-display {
   display: none !important;
   background-color: green; }
+
+.xblock-actions {
+  padding: 15px 0 10px 0 !important; }
 
 /*# sourceMappingURL=nesting_edit.css.map */

--- a/nesting/public/js/src/nesting_edit.js
+++ b/nesting/public/js/src/nesting_edit.js
@@ -44,8 +44,8 @@ function NestingEditXBlock(runtime, element, context) {
     $el.find('.input-container input[data-style]').each(function(){
       var key = $(this).data('style');
       styles[key] = $(this).val();
-    })     
-    
+    })
+
     xblock_data = {
       width: $el.find('input[id=width]').val(),
       styles: styles
@@ -70,7 +70,7 @@ function NestingEditXBlock(runtime, element, context) {
     if(i == template_list.length){
       setNestingXBlocks();
       return; //last call was last item in the array
-    } 
+    }
     $.ajax({
       url:'/xblock/',
       type: 'POST',
@@ -98,7 +98,7 @@ function NestingEditXBlock(runtime, element, context) {
     if(j == nesting_xblocks.length){
       studioSubmit();
       return; //last call was last item in the array
-    } 
+    }
     $.ajax({
       url:'/xblock/' + nesting_xblocks[j].locator + '/handler/studio_submit',
       type: 'POST',

--- a/nesting/public/sass/nesting_edit.scss
+++ b/nesting/public/sass/nesting_edit.scss
@@ -2,6 +2,11 @@
   margin-bottom: 0 !important;
 }
 
+.xblock-content {
+  height: 375px;
+  overflow-y: scroll;
+}
+
 .hidden{
     display: none;
   }
@@ -85,4 +90,8 @@
 .no-display{
   display: none !important;
   background-color: green;
+}
+
+.xblock-actions {
+  padding: 15px 0 10px 0!important;
 }


### PR DESCRIPTION
The modal window in Studio, if resized to a smaller width,
would overflow the container and cause the action buttons
to float in the middle of the container.
This commit limits the container height and adds
an overflow scroll to it.

![screenshot from 2017-09-25 16-47-28](https://user-images.githubusercontent.com/2808092/30814710-4604b81a-a211-11e7-9ecd-1361cd6abe9d.png)
